### PR TITLE
Fix duplicate IntelliJ annotation classes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
     id("kotlin-kapt")
 }
 
+// Exclude IntelliJ annotations to avoid duplicate class conflicts during build
+configurations.all {
+    exclude(group = "com.intellij", module = "annotations")
+}
+
 android {
     namespace = "com.example.bagstash"
     compileSdk = 35


### PR DESCRIPTION
## Summary
- exclude `com.intellij:annotations` from all configurations to avoid duplicate classes

## Testing
- `gradle tasks --no-daemon`
- `gradle build --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448918667c832996564ac699256136