### PR TITLE
Add local.properties example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ BagStash is a small Android application built with Jetpack Compose. This project
 ## Prerequisites
 
 - **JDK 11** or higher on your `PATH`
-- **Android SDK**. Set the path to your SDK in `local.properties` using the `sdk.dir` property. Android Studio normally generates this file for you.
+- **Android SDK**. Copy `local.properties.example` to `local.properties` and set `sdk.dir` to your SDK path. Android Studio normally generates this file for you.
 
 ## Building
 

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,0 +1,1 @@
+sdk.dir=/path/to/android-sdk


### PR DESCRIPTION
## Summary
- add `local.properties.example`
- update README about copying `local.properties.example`

## Testing
- `./gradlew --version` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68448ec2e5908329820be9f08a986adc