### PR TITLE
Switch to KSP plugin matching Kotlin 2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
     id("com.android.application") version "8.10.0" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
-    id("com.google.devtools.ksp") version "1.8.10-1.0.9" apply false
+    id("com.google.devtools.ksp") version "2.1.21-2.0.1" apply false
 }


### PR DESCRIPTION
## Summary
- use KSP plugin version built for Kotlin 2.1

## Testing
- `gradle build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684496e35dbc8329b55754223839e656